### PR TITLE
Add initial CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for your interest in contributing to the framework! We welcome contributions from developers like you. To ensure a smooth and collaborative development process, please follow these guidelines:
+
+## Development Process
+
+1. Fork the repository and create a new branch for your contribution.
+2. Make your changes and ensure they adhere to our coding standards (see next section).
+3. Test your changes thoroughly to ensure they do not introduce any regressions.
+4. Submit a pull request with a clear description of your changes and their purpose.
+
+## Testing
+
+We value the quality and stability of our framework. When contributing, please keep the following testing guidelines in mind:
+
+- Write unit tests for new features or bug fixes.
+- Ensure all existing tests pass before submitting your changes.
+- Consider writing integration tests if applicable.
+
+## Coding Standards
+
+To maintain a consistent codebase, we follow these coding standards:
+
+- Use meaningful variable and function names.
+- Write clear and concise comments to explain complex logic.
+- Follow the PSR coding standards for PHP code.
+- Use consistent indentation and formatting.
+
+By following these guidelines, you can help us maintain a high-quality framework and ensure a smooth collaboration process.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Oze Framework
+
+The Oze Framework is a powerful tool designed to assist developers who have a solid understanding of basic PHP and are looking to delve into the world of MVC (Model-View-Controller) architecture. By providing a seamless transition towards using frameworks like Laravel, Oze Framework empowers developers to enhance their skills and build robust applications. With its intuitive design and comprehensive documentation, Oze Framework is the perfect stepping stone for those seeking to master the MVC pattern and unlock the full potential of their PHP development journey.
+
+<!-- Architecture and Core Components -->
+<!-- Detailed explanation of the framework’s architecture (e.g., MVC, HMVC). -->
+<!-- Description of core components such as routing, controllers, models, views, etc. -->
+<!-- Overview of internal mechanisms like dependency injection and event handling, if applicable. -->
+
+## Installation
+
+<!-- System requirements (minimum PHP version, extensions, database, etc.). -->
+<!-- Step-by-step installation instructions via Composer or manually. -->
+<!-- Environment setup guidelines. -->
+
+> coming soon
+
+## Basic Usage
+
+<!-- "Hello World" example to quickly demonstrate the framework in action. -->
+<!-- Explanation of directory structure and key files. -->
+<!-- Overview of basic configuration settings. -->
+
+> coming soon
+
+## Usage Examples
+
+<!-- Code examples for common use cases. -->
+<!-- Best practices for utilizing the framework effectively. -->
+
+> coming soon
+
+## API Reference
+
+<!-- Comprehensive documentation for all classes, methods, and functions within the framework. -->
+<!-- Detailed explanations of parameters, return values, and example usages. -->
+
+> coming soon
+
+## Tutorials and FAQ
+
+<!-- Step-by-step tutorials for building a simple application. -->
+<!-- Frequently Asked Questions (FAQ) section with detailed answers. -->
+
+> coming soon
+
+## Debugging and Error Handling
+
+<!-- Instructions on debugging and handling errors. -->
+<!-- Explanation of logging, exception handling, and solutions for common issues. -->
+
+> coming soon
+
+## Contributing
+
+For guidelines on how to contribute to the framework, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file. It provides detailed instructions on how to submit bug reports, suggest new features, and contribute code to the project. We welcome contributions from the community and appreciate any help in improving the framework.
+
+## Changelog
+
+<!-- Record of changes for each released version. -->
+<!-- Information on new features, bug fixes, and other updates. -->
+
+> coming soon
+
+## License and Copyright
+
+The Oze Framework is licensed under the MIT license, which can be found in the [LICENSE.md](LICENSE.md) file. The MIT license allows users to freely use, modify, and distribute the framework, both for personal and commercial purposes. It also provides a disclaimer of warranty and limitation of liability. By using the framework, users agree to comply with the terms and conditions stated in the MIT license.


### PR DESCRIPTION
This pull request adds the initial CONTRIBUTING.md and README.md files to the repository. The CONTRIBUTING.md file provides guidelines for contributing to the framework, including the development process, testing guidelines, and coding standards. The README.md file provides an overview of the Oze Framework, including its purpose, installation instructions, basic usage, and other sections such as API reference, tutorials, and contributing guidelines. These files will help users understand how to contribute to the project and provide comprehensive documentation for using the framework.

fix #24